### PR TITLE
Fix issue with special character in path

### DIFF
--- a/plugin/index.vim
+++ b/plugin/index.vim
@@ -95,7 +95,7 @@ fun! s:EditorConfigParse()
   let l:shellCmd = join([
     \'cd '.s:plugDir,
     \'&&',
-    \'node editorconfig-vim.js '.l:fullPathToCheck
+    \'node editorconfig-vim.js '.'"'.l:fullPathToCheck.'"'
   \])
   let l:jobCmd = [s:bashPath, '-c', l:shellCmd]
   let s:curJob = job_start(l:jobCmd,


### PR DESCRIPTION
Since it is a bash command, we need to wrap the `fullPathToCheck` in quotes so that bash knows it is just simple string.